### PR TITLE
When URL cannot be reached generate exception

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     ],
     "require": {
         "php": ">= 5.3.0",
+        "ext-imagick": "*",
         "symfony/dom-crawler": "~2.4",
         "symfony/css-selector": "~2.4"
     },

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
     ],
     "require": {
         "php": ">= 5.3.0",
-        "ext-imagick": "*",
         "symfony/dom-crawler": "~2.4",
         "symfony/css-selector": "~2.4"
     },

--- a/src/ThumbnailFinder.php
+++ b/src/ThumbnailFinder.php
@@ -61,7 +61,12 @@ class ThumbnailFinder
             ),
         ));
 
-        $html = file_get_contents($url, false, $ctx);
+        $html = @file_get_contents($url, false, $ctx);
+        if ($html === false) {
+            throw new \Exception("Could not contact URL");
+        } else {
+            return $this->findThumbnailFromHtml($html, $url);
+        }
 
         return $this->findThumbnailFromHtml($html, $url);
     }


### PR DESCRIPTION
Had an issue where a URL could not be reached. file_get_contents creates a warning. Supress this and generate an exception instead.
